### PR TITLE
Removed builder pattern from ApiToken

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -152,7 +152,7 @@
 
         <!-- Checks for class design                         -->
         <!-- See http://checkstyle.sf.net/config_design.html -->
-        <module name="FinalClass"/>
+<!--        <module name="FinalClass"/>-->
         <module name="InterfaceIsType"/>
         <module name="VisibilityModifier"/>
 

--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -152,7 +152,7 @@
 
         <!-- Checks for class design                         -->
         <!-- See http://checkstyle.sf.net/config_design.html -->
-<!--        <module name="FinalClass"/>-->
+        <module name="FinalClass"/>
         <module name="InterfaceIsType"/>
         <module name="VisibilityModifier"/>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.blackforestsolutions</groupId>
     <artifactId>dravelopsdatamodel</artifactId>
-    <version>14.0.1</version>
+    <version>14.0.2</version>
 
     <parent>
         <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.blackforestsolutions</groupId>
     <artifactId>dravelopsdatamodel</artifactId>
-    <version>13.0.6</version>
+    <version>14.0.0</version>
 
     <parent>
         <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.blackforestsolutions</groupId>
     <artifactId>dravelopsdatamodel</artifactId>
-    <version>13.0.5</version>
+    <version>13.0.6</version>
 
     <parent>
         <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.blackforestsolutions</groupId>
     <artifactId>dravelopsdatamodel</artifactId>
-    <version>14.0.0</version>
+    <version>14.0.1</version>
 
     <parent>
         <groupId>org.springframework.boot</groupId>

--- a/src/main/java/de/blackforestsolutions/dravelopsdatamodel/ApiToken.java
+++ b/src/main/java/de/blackforestsolutions/dravelopsdatamodel/ApiToken.java
@@ -1,185 +1,162 @@
 package de.blackforestsolutions.dravelopsdatamodel;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
-import lombok.experimental.Accessors;
 import org.springframework.data.geo.Distance;
 
 import java.time.ZonedDateTime;
 import java.util.*;
 
+@Setter
 @Getter
-@JsonDeserialize(builder = ApiToken.ApiTokenBuilder.class)
 public class ApiToken {
 
-    private final String host;
-    private final String protocol;
-    private final Integer port;
-    private final String departure;
-    private final Point departureCoordinate;
-    private final String arrival;
-    private final Point arrivalCoordinate;
-    private final ZonedDateTime dateTime;
-    private final Boolean isArrivalDateTime;
-    private final Locale language;
-    private final String router;
-    private final Distance radiusInKilometers;
-    private final Boolean hasDetails;
-    private final Boolean hasReferences;
-    private final String path;
-    private final Integer maxResults;
-    private final String apiVersion;
-    private final Box box;
-    private final List<String> layers;
-    private final Integer maxPastDaysInCalendar;
-    private final Integer journeySearchWindowInMinutes;
-    private final String gtfsProvider;
-    private final String gtfsUrl;
-    private final Map<String, String> headers;
-    private final Long retryTimeInSeconds;
+    private String host;
+    private String protocol;
+    private Integer port = -1;
+    private String departure;
+    private Point departureCoordinate;
+    private String arrival;
+    private Point arrivalCoordinate;
+    private ZonedDateTime dateTime;
+    private Boolean isArrivalDateTime;
+    private Locale language;
+    private String router;
+    private Distance radiusInKilometers;
+    private Boolean hasDetails;
+    private Boolean hasReferences;
+    private String path;
+    private Integer maxResults;
+    private String apiVersion;
+    private Box box;
+    private List<String> layers = new LinkedList<>();
+    private Integer maxPastDaysInCalendar;
+    private Integer journeySearchWindowInMinutes;
+    private String gtfsProvider;
+    private String gtfsUrl;
+    private Map<String, String> headers = new HashMap<>();
+    private Long retryTimeInSeconds;
 
-    private ApiToken(ApiTokenBuilder apiTokenBuilder) {
-        this.host = apiTokenBuilder.getHost();
-        this.protocol = apiTokenBuilder.getProtocol();
-        this.port = apiTokenBuilder.getPort();
-        this.departure = apiTokenBuilder.getDeparture();
-        this.departureCoordinate = apiTokenBuilder.getDepartureCoordinate();
-        this.arrival = apiTokenBuilder.getArrival();
-        this.arrivalCoordinate = apiTokenBuilder.getArrivalCoordinate();
-        this.dateTime = apiTokenBuilder.getDateTime();
-        this.isArrivalDateTime = apiTokenBuilder.getIsArrivalDateTime();
-        this.language = apiTokenBuilder.getLanguage();
-        this.router = apiTokenBuilder.getRouter();
-        this.radiusInKilometers = apiTokenBuilder.getRadiusInKilometers();
-        this.hasDetails = apiTokenBuilder.getHasDetails();
-        this.hasReferences = apiTokenBuilder.getHasReferences();
-        this.path = apiTokenBuilder.getPath();
-        this.maxResults = apiTokenBuilder.getMaxResults();
-        this.apiVersion = apiTokenBuilder.getApiVersion();
-        this.box = apiTokenBuilder.getBox();
-        this.layers = apiTokenBuilder.getLayers();
-        this.maxPastDaysInCalendar = apiTokenBuilder.getMaxPastDaysInCalendar();
-        this.journeySearchWindowInMinutes = apiTokenBuilder.getJourneySearchWindowInMinutes();
-        this.gtfsProvider = apiTokenBuilder.getGtfsProvider();
-        this.gtfsUrl = apiTokenBuilder.getGtfsUrl();
-        this.headers = apiTokenBuilder.getHeaders();
-        this.retryTimeInSeconds = apiTokenBuilder.getRetryTimeInSeconds();
-    }
-
-    @Setter
-    @Getter
-    @Accessors(chain = true)
-    @JsonPOJOBuilder(withPrefix = "set")
-    @NoArgsConstructor
-    public static class ApiTokenBuilder {
-
-        private String host;
-        private String protocol;
-        private Integer port = -1;
-        private String departure;
-        private Point departureCoordinate;
-        private String arrival;
-        private Point arrivalCoordinate;
-        private ZonedDateTime dateTime;
-        private Boolean isArrivalDateTime;
-        private Locale language;
-        private String router;
-        private Distance radiusInKilometers;
-        private Boolean hasDetails;
-        private Boolean hasReferences;
-        private String path;
-        private Integer maxResults;
-        private String apiVersion;
-        private Box box;
-        private List<String> layers = new LinkedList<>();
-        private Integer maxPastDaysInCalendar;
-        private Integer journeySearchWindowInMinutes;
-        private String gtfsProvider;
-        private String gtfsUrl;
-        private Map<String, String> headers = new HashMap<>();
-        private Long retryTimeInSeconds;
-
-        /**
-         * This warning indicates a duplicated code fragment.
-         * However, since there are three constructors of different types, one solution would be to create a method with a
-         * large number of parameters. Since this leads to NumberParameter violation, I leave it with a constructor.
-         * three constructors are also more readable than one method with many params and three constructors calling it.
-         *
-         * @param apiTokenBuilder to copy to {@link ApiTokenBuilder}
-         */
-        @SuppressWarnings("CPD-START")
-        public ApiTokenBuilder(ApiTokenBuilder apiTokenBuilder) {
-            this.host = apiTokenBuilder.getHost();
-            this.protocol = apiTokenBuilder.getProtocol();
-            this.port = apiTokenBuilder.getPort();
-            this.departure = apiTokenBuilder.getDeparture();
-            this.departureCoordinate = apiTokenBuilder.getDepartureCoordinate();
-            this.arrival = apiTokenBuilder.getArrival();
-            this.arrivalCoordinate = apiTokenBuilder.getArrivalCoordinate();
-            this.dateTime = apiTokenBuilder.getDateTime();
-            this.isArrivalDateTime = apiTokenBuilder.getIsArrivalDateTime();
-            this.language = apiTokenBuilder.getLanguage();
-            this.router = apiTokenBuilder.getRouter();
-            this.radiusInKilometers = apiTokenBuilder.getRadiusInKilometers();
-            this.hasDetails = apiTokenBuilder.getHasDetails();
-            this.hasReferences = apiTokenBuilder.getHasReferences();
-            this.path = apiTokenBuilder.getPath();
-            this.maxResults = apiTokenBuilder.getMaxResults();
-            this.apiVersion = apiTokenBuilder.getApiVersion();
-            this.box = apiTokenBuilder.getBox();
-            this.layers = apiTokenBuilder.getLayers();
-            this.maxPastDaysInCalendar = apiTokenBuilder.getMaxPastDaysInCalendar();
-            this.journeySearchWindowInMinutes = apiTokenBuilder.getJourneySearchWindowInMinutes();
-            this.gtfsProvider = apiTokenBuilder.getGtfsProvider();
-            this.gtfsUrl = apiTokenBuilder.getGtfsUrl();
-            this.headers = apiTokenBuilder.getHeaders();
-            this.retryTimeInSeconds = apiTokenBuilder.getRetryTimeInSeconds();
-        }
-
-        /**
-         * This warning indicates a duplicated code fragment.
-         * However, since there are three constructors of different types, one solution would be to create a method with a
-         * large number of parameters. Since this leads to NumberParameter violation, I leave it with a constructor.
-         * three constructors are also more readable than one method with many params and three constructors calling it.
-         *
-         * @param apiToken to copy to {@link ApiTokenBuilder}
-         */
-        @SuppressWarnings("CPD-START")
-        public ApiTokenBuilder(ApiToken apiToken) {
-            this.host = apiToken.getHost();
-            this.protocol = apiToken.getProtocol();
-            this.port = apiToken.getPort();
-            this.departure = apiToken.getDeparture();
-            this.departureCoordinate = apiToken.getDepartureCoordinate();
-            this.arrival = apiToken.getArrival();
-            this.arrivalCoordinate = apiToken.getArrivalCoordinate();
-            this.dateTime = apiToken.getDateTime();
-            this.isArrivalDateTime = apiToken.getIsArrivalDateTime();
-            this.language = apiToken.getLanguage();
-            this.router = apiToken.getRouter();
-            this.radiusInKilometers = apiToken.getRadiusInKilometers();
-            this.hasDetails = apiToken.getHasDetails();
-            this.hasReferences = apiToken.getHasReferences();
-            this.path = apiToken.getPath();
-            this.maxResults = apiToken.getMaxResults();
-            this.apiVersion = apiToken.getApiVersion();
-            this.box = apiToken.getBox();
-            this.layers = apiToken.getLayers();
-            this.maxPastDaysInCalendar = apiToken.getMaxPastDaysInCalendar();
-            this.journeySearchWindowInMinutes = apiToken.getJourneySearchWindowInMinutes();
-            this.gtfsProvider = apiToken.getGtfsProvider();
-            this.gtfsUrl = apiToken.getGtfsUrl();
-            this.headers = apiToken.getHeaders();
-            this.retryTimeInSeconds = apiToken.getRetryTimeInSeconds();
-        }
-
-        public ApiToken build() {
-            return new ApiToken(this);
-        }
+    public ApiToken() {
 
     }
 
+    public ApiToken(ApiToken apiToken) {
+        this.host = apiToken.getHost();
+        this.protocol = apiToken.getProtocol();
+        this.port = apiToken.getPort();
+        this.departure = apiToken.getDeparture();
+        this.departureCoordinate = apiToken.getDepartureCoordinate();
+        this.arrival = apiToken.getArrival();
+        this.arrivalCoordinate = apiToken.getArrivalCoordinate();
+        this.dateTime = apiToken.getDateTime();
+        this.isArrivalDateTime = apiToken.getIsArrivalDateTime();
+        this.language = apiToken.getLanguage();
+        this.router = apiToken.getRouter();
+        this.radiusInKilometers = apiToken.getRadiusInKilometers();
+        this.hasDetails = apiToken.getHasDetails();
+        this.hasReferences = apiToken.getHasReferences();
+        this.path = apiToken.getPath();
+        this.maxResults = apiToken.getMaxResults();
+        this.apiVersion = apiToken.getApiVersion();
+        this.box = apiToken.getBox();
+        this.layers = apiToken.getLayers();
+        this.maxPastDaysInCalendar = apiToken.getMaxPastDaysInCalendar();
+        this.journeySearchWindowInMinutes = apiToken.getJourneySearchWindowInMinutes();
+        this.gtfsProvider = apiToken.getGtfsProvider();
+        this.gtfsUrl = apiToken.getGtfsUrl();
+        this.headers = apiToken.getHeaders();
+        this.retryTimeInSeconds = apiToken.getRetryTimeInSeconds();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ApiToken that = (ApiToken) o;
+        return Objects.equals(host, that.host)
+                &&
+                Objects.equals(protocol, that.protocol)
+                &&
+                Objects.equals(port, that.port)
+                &&
+                Objects.equals(departure, that.departure)
+                &&
+                Objects.equals(departureCoordinate, that.departureCoordinate)
+                &&
+                Objects.equals(arrival, that.arrival)
+                &&
+                Objects.equals(arrivalCoordinate, that.arrivalCoordinate)
+                &&
+                Objects.equals(dateTime, that.dateTime)
+                &&
+                Objects.equals(isArrivalDateTime, that.isArrivalDateTime)
+                &&
+                Objects.equals(language, that.language)
+                &&
+                Objects.equals(router, that.router)
+                &&
+                Objects.equals(radiusInKilometers, that.radiusInKilometers)
+                &&
+                Objects.equals(hasDetails, that.hasDetails)
+                &&
+                Objects.equals(hasReferences, that.hasReferences)
+                &&
+                Objects.equals(path, that.path)
+                &&
+                Objects.equals(maxResults, that.maxResults)
+                &&
+                Objects.equals(apiVersion, that.apiVersion)
+                &&
+                Objects.equals(box, that.box)
+                &&
+                Objects.equals(layers, that.layers)
+                &&
+                Objects.equals(maxPastDaysInCalendar, that.maxPastDaysInCalendar)
+                &&
+                Objects.equals(journeySearchWindowInMinutes, that.journeySearchWindowInMinutes)
+                &&
+                Objects.equals(gtfsProvider, that.gtfsProvider)
+                &&
+                Objects.equals(gtfsUrl, that.gtfsUrl)
+                &&
+                Objects.equals(headers, that.headers)
+                &&
+                Objects.equals(retryTimeInSeconds, that.retryTimeInSeconds);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                host,
+                protocol,
+                port,
+                departure,
+                departureCoordinate,
+                arrival,
+                arrivalCoordinate,
+                dateTime,
+                isArrivalDateTime,
+                language,
+                router,
+                radiusInKilometers,
+                hasDetails,
+                hasReferences,
+                path,
+                maxResults,
+                apiVersion,
+                box,
+                layers,
+                maxPastDaysInCalendar,
+                journeySearchWindowInMinutes,
+                gtfsProvider,
+                gtfsUrl,
+                headers,
+                retryTimeInSeconds
+        );
+    }
 }

--- a/src/main/java/de/blackforestsolutions/dravelopsdatamodel/ApiToken.java
+++ b/src/main/java/de/blackforestsolutions/dravelopsdatamodel/ApiToken.java
@@ -35,7 +35,7 @@ public class ApiToken {
     private String gtfsProvider;
     private String gtfsUrl;
     private Map<String, String> headers = new HashMap<>();
-    private Long retryTimeInSeconds;
+    private Long retryTimeInMilliseconds;
 
     public ApiToken() {
 
@@ -66,7 +66,7 @@ public class ApiToken {
         this.gtfsProvider = apiToken.getGtfsProvider();
         this.gtfsUrl = apiToken.getGtfsUrl();
         this.headers = apiToken.getHeaders();
-        this.retryTimeInSeconds = apiToken.getRetryTimeInSeconds();
+        this.retryTimeInMilliseconds = apiToken.getRetryTimeInMilliseconds();
     }
 
     @Override
@@ -126,7 +126,7 @@ public class ApiToken {
                 &&
                 Objects.equals(headers, that.headers)
                 &&
-                Objects.equals(retryTimeInSeconds, that.retryTimeInSeconds);
+                Objects.equals(retryTimeInMilliseconds, that.retryTimeInMilliseconds);
     }
 
     @Override
@@ -156,7 +156,7 @@ public class ApiToken {
                 gtfsProvider,
                 gtfsUrl,
                 headers,
-                retryTimeInSeconds
+                retryTimeInMilliseconds
         );
     }
 }

--- a/src/main/java/de/blackforestsolutions/dravelopsdatamodel/ApiToken.java
+++ b/src/main/java/de/blackforestsolutions/dravelopsdatamodel/ApiToken.java
@@ -13,7 +13,7 @@ import java.util.*;
 
 @Getter
 @JsonDeserialize(builder = ApiToken.ApiTokenBuilder.class)
-public final class ApiToken {
+public class ApiToken {
 
     private final String host;
     private final String protocol;

--- a/src/main/resources/json/apitoken.json
+++ b/src/main/resources/json/apitoken.json
@@ -58,5 +58,5 @@
   "headers": {
     "Token": "123"
   },
-  "retryTimeInSeconds": 10
+  "retryTimeInMilliseconds": 10
 }

--- a/src/test/java/de/blackforestsolutions/dravelopsdatamodel/ApiTokenTest.java
+++ b/src/test/java/de/blackforestsolutions/dravelopsdatamodel/ApiTokenTest.java
@@ -1,40 +1,24 @@
 package de.blackforestsolutions.dravelopsdatamodel;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
-import static de.blackforestsolutions.dravelopsdatamodel.objectmothers.ApiTokenObjectMother.getApiTokenBuilderWithNoEmptyFields;
 import static de.blackforestsolutions.dravelopsdatamodel.objectmothers.ApiTokenObjectMother.getApiTokenWithNoEmptyFields;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ApiTokenTest {
 
     @Test
-    void test_build_returns_an_equal_apiToken() {
-        ApiToken.ApiTokenBuilder testData = getApiTokenBuilderWithNoEmptyFields();
-        ApiToken expectedApiToken = getApiTokenWithNoEmptyFields();
-
-        ApiToken result = testData.build();
-
-        assertThat(result).isEqualToComparingFieldByFieldRecursively(expectedApiToken);
+    void test_equals_and_hashCode_contract_for_apiToken() {
+        EqualsVerifier.simple().forClass(ApiToken.class).verify();
     }
 
     @Test
     void test_copy_constructor_returns_an_equal_apiToken() {
         ApiToken testData = getApiTokenWithNoEmptyFields();
-        ApiToken.ApiTokenBuilder expectedApiTokenBuilder = getApiTokenBuilderWithNoEmptyFields();
 
-        ApiToken.ApiTokenBuilder result = new ApiToken.ApiTokenBuilder(testData);
-
-        assertThat(result).isEqualToComparingFieldByFieldRecursively(expectedApiTokenBuilder);
-    }
-
-    @Test
-    void test_copy_constructor_returns_an_equal_apiToken_and_different_reference() {
-        ApiToken.ApiTokenBuilder testData = getApiTokenBuilderWithNoEmptyFields();
-
-        ApiToken.ApiTokenBuilder result = new ApiToken.ApiTokenBuilder(testData);
+        ApiToken result = new ApiToken(testData);
 
         assertThat(result).isEqualToComparingFieldByFieldRecursively(testData);
-        assertThat(result).isNotEqualTo(testData);
     }
 }

--- a/src/test/java/de/blackforestsolutions/dravelopsdatamodel/objectmothers/ApiTokenObjectMother.java
+++ b/src/test/java/de/blackforestsolutions/dravelopsdatamodel/objectmothers/ApiTokenObjectMother.java
@@ -67,401 +67,399 @@ public class ApiTokenObjectMother {
     private static final long DEFAULT_TEST_RETRY_TIME_IN_SECONDS = 10L;
 
 
-    public static ApiToken.ApiTokenBuilder getApiTokenBuilderWithNoEmptyFields() {
-        return new ApiToken.ApiTokenBuilder()
-                .setHost(HOST)
-                .setProtocol(PROTOCOL)
-                .setPort(DEFAULT_TEST_PORT)
-                .setDeparture(DEFAULT_TEST_DEPARTURE)
-                .setDepartureCoordinate(DEFAULT_TEST_DEPARTURE_COORDINATE)
-                .setArrival(DEFAULT_TEST_ARRIVAL)
-                .setArrivalCoordinate(DEFAULT_TEST_ARRIVAL_COORDINATE)
-                .setDateTime(DEFAULT_TEST_DATE_TIME)
-                .setIsArrivalDateTime(DEFAULT_TEST_IS_ARRIVAL_DATE_TIME)
-                .setLanguage(DEFAULT_TEST_LANGUAGE)
-                .setRouter(DEFAULT_TEST_ROUTER)
-                .setRadiusInKilometers(DEFAULT_TEST_RADIUS_IN_KILOMETERS)
-                .setHasDetails(DEFAULT_TEST_OTP_HAS_DETAILS)
-                .setHasReferences(DEFAULT_TEST_OTP_HAS_REFERENCES)
-                .setPath(DEFAULT_TEST_PATH)
-                .setApiVersion(DEFAULT_TEST_PELIAS_API_VERSION)
-                .setMaxResults(DEFAULT_TEST_PELIAS_REVERSE_RESULTS)
-                .setBox(DEFAULT_TEST_BOX)
-                .setLayers(DEFAULT_TEST_PELIAS_LAYERS)
-                .setMaxPastDaysInCalendar(DEFAULT_TEST_MAX_PAST_DAYS_IN_CALENDAR)
-                .setJourneySearchWindowInMinutes(DEFAULT_TEST_JOURNEY_SEARCH_WINDOW)
-                .setGtfsProvider(DEFAULT_TEST_GTFS_PROVIDER)
-                .setGtfsUrl(DEFAULT_TEST_GTFS_URL)
-                .setHeaders(DEFAULT_TEST_HEADERS)
-                .setRetryTimeInSeconds(DEFAULT_TEST_RETRY_TIME_IN_SECONDS);
-    }
-
     public static ApiToken getApiTokenWithNoEmptyFields() {
-        return new ApiToken.ApiTokenBuilder(getApiTokenBuilderWithNoEmptyFields())
-                .build();
+        ApiToken apiToken = new ApiToken();
+        apiToken.setHost(HOST);
+        apiToken.setProtocol(PROTOCOL);
+        apiToken.setPort(DEFAULT_TEST_PORT);
+        apiToken.setDeparture(DEFAULT_TEST_DEPARTURE);
+        apiToken.setDepartureCoordinate(DEFAULT_TEST_DEPARTURE_COORDINATE);
+        apiToken.setArrival(DEFAULT_TEST_ARRIVAL);
+        apiToken.setArrivalCoordinate(DEFAULT_TEST_ARRIVAL_COORDINATE);
+        apiToken.setDateTime(DEFAULT_TEST_DATE_TIME);
+        apiToken.setIsArrivalDateTime(DEFAULT_TEST_IS_ARRIVAL_DATE_TIME);
+        apiToken.setLanguage(DEFAULT_TEST_LANGUAGE);
+        apiToken.setRouter(DEFAULT_TEST_ROUTER);
+        apiToken.setRadiusInKilometers(DEFAULT_TEST_RADIUS_IN_KILOMETERS);
+        apiToken.setHasDetails(DEFAULT_TEST_OTP_HAS_DETAILS);
+        apiToken.setHasReferences(DEFAULT_TEST_OTP_HAS_REFERENCES);
+        apiToken.setPath(DEFAULT_TEST_PATH);
+        apiToken.setApiVersion(DEFAULT_TEST_PELIAS_API_VERSION);
+        apiToken.setMaxResults(DEFAULT_TEST_PELIAS_REVERSE_RESULTS);
+        apiToken.setBox(DEFAULT_TEST_BOX);
+        apiToken.setLayers(DEFAULT_TEST_PELIAS_LAYERS);
+        apiToken.setMaxPastDaysInCalendar(DEFAULT_TEST_MAX_PAST_DAYS_IN_CALENDAR);
+        apiToken.setJourneySearchWindowInMinutes(DEFAULT_TEST_JOURNEY_SEARCH_WINDOW);
+        apiToken.setGtfsProvider(DEFAULT_TEST_GTFS_PROVIDER);
+        apiToken.setGtfsUrl(DEFAULT_TEST_GTFS_URL);
+        apiToken.setHeaders(DEFAULT_TEST_HEADERS);
+        apiToken.setRetryTimeInSeconds(DEFAULT_TEST_RETRY_TIME_IN_SECONDS);
+        return apiToken;
     }
 
     public static ApiToken getApiTokenWithNoEmptyFieldsBy(Point arrivalCoordinate, Point departureCoordinate, ZonedDateTime dateTime, Locale language) {
-        return getApiTokenBuilderWithNoEmptyFields()
-                .setArrivalCoordinate(arrivalCoordinate)
-                .setDepartureCoordinate(departureCoordinate)
-                .setDateTime(dateTime)
-                .setLanguage(language)
-                .build();
+        ApiToken apiToken = new ApiToken(getApiTokenWithNoEmptyFields());
+        apiToken.setArrivalCoordinate(arrivalCoordinate);
+        apiToken.setDepartureCoordinate(departureCoordinate);
+        apiToken.setDateTime(dateTime);
+        apiToken.setLanguage(language);
+        return apiToken;
     }
 
     // Start
     // Journey Token Request Chain from StargateService to OpenTripPlanner
     public static ApiToken getJourneyUserRequestToken() {
-        return new ApiToken.ApiTokenBuilder()
-                .setIsArrivalDateTime(DEFAULT_TEST_IS_ARRIVAL_DATE_TIME)
-                .setDateTime(DEFAULT_TEST_DATE_TIME)
-                .setDepartureCoordinate(DEFAULT_TEST_DEPARTURE_COORDINATE)
-                .setArrivalCoordinate(DEFAULT_TEST_ARRIVAL_COORDINATE)
-                .setLanguage(DEFAULT_TEST_LANGUAGE)
-                .build();
+        ApiToken apiToken = new ApiToken();
+        apiToken.setIsArrivalDateTime(DEFAULT_TEST_IS_ARRIVAL_DATE_TIME);
+        apiToken.setDateTime(DEFAULT_TEST_DATE_TIME);
+        apiToken.setDepartureCoordinate(DEFAULT_TEST_DEPARTURE_COORDINATE);
+        apiToken.setArrivalCoordinate(DEFAULT_TEST_ARRIVAL_COORDINATE);
+        apiToken.setLanguage(DEFAULT_TEST_LANGUAGE);
+        return apiToken;
     }
 
     public static ApiToken getConfiguredRoutePersistenceApiToken() {
-        return new ApiToken.ApiTokenBuilder()
-                .setProtocol(PROTOCOL)
-                .setHost(HOST)
-                .setPort(ROUTE_PERSISTENCE_PORT)
-                .setPath(JOURNEY_CONTROLLER_PATH)
-                .setMaxResults(DEFAULT_TEST_MAX_RESULTS)
-                .build();
+        ApiToken apiToken = new ApiToken();
+        apiToken.setProtocol(PROTOCOL);
+        apiToken.setHost(HOST);
+        apiToken.setPort(ROUTE_PERSISTENCE_PORT);
+        apiToken.setPath(JOURNEY_CONTROLLER_PATH);
+        apiToken.setMaxResults(DEFAULT_TEST_MAX_RESULTS);
+        return apiToken;
     }
 
     public static ApiToken getRoutePersistenceApiToken() {
-        return new ApiToken.ApiTokenBuilder()
-                .setProtocol(PROTOCOL)
-                .setHost(HOST)
-                .setPort(ROUTE_PERSISTENCE_PORT)
-                .setPath(JOURNEY_CONTROLLER_PATH)
-                .setMaxResults(DEFAULT_TEST_MAX_RESULTS)
-                .setIsArrivalDateTime(DEFAULT_TEST_IS_ARRIVAL_DATE_TIME)
-                .setDateTime(DEFAULT_TEST_DATE_TIME)
-                .setDepartureCoordinate(DEFAULT_TEST_DEPARTURE_COORDINATE)
-                .setArrivalCoordinate(DEFAULT_TEST_ARRIVAL_COORDINATE)
-                .setLanguage(DEFAULT_TEST_LANGUAGE)
-                .build();
+        ApiToken apiToken = new ApiToken();
+        apiToken.setProtocol(PROTOCOL);
+        apiToken.setHost(HOST);
+        apiToken.setPort(ROUTE_PERSISTENCE_PORT);
+        apiToken.setPath(JOURNEY_CONTROLLER_PATH);
+        apiToken.setMaxResults(DEFAULT_TEST_MAX_RESULTS);
+        apiToken.setIsArrivalDateTime(DEFAULT_TEST_IS_ARRIVAL_DATE_TIME);
+        apiToken.setDateTime(DEFAULT_TEST_DATE_TIME);
+        apiToken.setDepartureCoordinate(DEFAULT_TEST_DEPARTURE_COORDINATE);
+        apiToken.setArrivalCoordinate(DEFAULT_TEST_ARRIVAL_COORDINATE);
+        apiToken.setLanguage(DEFAULT_TEST_LANGUAGE);
+        return apiToken;
     }
 
     public static ApiToken getConfiguredJourneyOtpMapperApiToken() {
-        return new ApiToken.ApiTokenBuilder()
-                .setProtocol(PROTOCOL)
-                .setHost(HOST)
-                .setPort(OTP_MAPPER_SERVICE_PORT)
-                .setPath(JOURNEY_CONTROLLER_PATH)
-                .setMaxResults(DEFAULT_TEST_MAX_RESULTS)
-                .build();
+        ApiToken apiToken = new ApiToken();
+        apiToken.setProtocol(PROTOCOL);
+        apiToken.setHost(HOST);
+        apiToken.setPort(OTP_MAPPER_SERVICE_PORT);
+        apiToken.setPath(JOURNEY_CONTROLLER_PATH);
+        apiToken.setMaxResults(DEFAULT_TEST_MAX_RESULTS);
+        return apiToken;
     }
 
     public static ApiToken getJourneyOtpMapperApiToken() {
-        return new ApiToken.ApiTokenBuilder()
-                .setProtocol(PROTOCOL)
-                .setHost(HOST)
-                .setPort(OTP_MAPPER_SERVICE_PORT)
-                .setPath(JOURNEY_CONTROLLER_PATH)
-                .setMaxResults(DEFAULT_TEST_MAX_RESULTS)
-                .setIsArrivalDateTime(DEFAULT_TEST_IS_ARRIVAL_DATE_TIME)
-                .setDateTime(DEFAULT_TEST_DATE_TIME)
-                .setDepartureCoordinate(DEFAULT_TEST_DEPARTURE_COORDINATE)
-                .setArrivalCoordinate(DEFAULT_TEST_ARRIVAL_COORDINATE)
-                .setLanguage(DEFAULT_TEST_LANGUAGE)
-                .build();
+        ApiToken apiToken = new ApiToken();
+        apiToken.setProtocol(PROTOCOL);
+        apiToken.setHost(HOST);
+        apiToken.setPort(OTP_MAPPER_SERVICE_PORT);
+        apiToken.setPath(JOURNEY_CONTROLLER_PATH);
+        apiToken.setMaxResults(DEFAULT_TEST_MAX_RESULTS);
+        apiToken.setIsArrivalDateTime(DEFAULT_TEST_IS_ARRIVAL_DATE_TIME);
+        apiToken.setDateTime(DEFAULT_TEST_DATE_TIME);
+        apiToken.setDepartureCoordinate(DEFAULT_TEST_DEPARTURE_COORDINATE);
+        apiToken.setArrivalCoordinate(DEFAULT_TEST_ARRIVAL_COORDINATE);
+        apiToken.setLanguage(DEFAULT_TEST_LANGUAGE);
+        return apiToken;
     }
 
     public static ApiToken getConfiguredPeliasReverseApiToken() {
-        return new ApiToken.ApiTokenBuilder()
-                .setProtocol(PROTOCOL)
-                .setHost(HOST)
-                .setPort(PELIAS_PORT)
-                .setApiVersion(DEFAULT_TEST_PELIAS_API_VERSION)
-                .setMaxResults(DEFAULT_TEST_PELIAS_REVERSE_RESULTS)
-                .setDeparture(DEFAULT_TEST_DEPARTURE_PLACEHOLDER)
-                .setArrival(DEFAULT_TEST_ARRIVAL_PLACEHOLDER)
-                .setLayers(DEFAULT_TEST_PELIAS_LAYERS)
-                .build();
+        ApiToken apiToken = new ApiToken();
+        apiToken.setProtocol(PROTOCOL);
+        apiToken.setHost(HOST);
+        apiToken.setPort(PELIAS_PORT);
+        apiToken.setApiVersion(DEFAULT_TEST_PELIAS_API_VERSION);
+        apiToken.setMaxResults(DEFAULT_TEST_PELIAS_REVERSE_RESULTS);
+        apiToken.setDeparture(DEFAULT_TEST_DEPARTURE_PLACEHOLDER);
+        apiToken.setArrival(DEFAULT_TEST_ARRIVAL_PLACEHOLDER);
+        apiToken.setLayers(DEFAULT_TEST_PELIAS_LAYERS);
+        return apiToken;
     }
 
     public static ApiToken getPeliasReverseApiToken() {
-        return new ApiToken.ApiTokenBuilder()
-                .setProtocol(PROTOCOL)
-                .setHost(HOST)
-                .setPort(PELIAS_PORT)
-                .setApiVersion(DEFAULT_TEST_PELIAS_API_VERSION)
-                .setMaxResults(DEFAULT_TEST_PELIAS_REVERSE_RESULTS)
-                .setDeparture(DEFAULT_TEST_DEPARTURE_PLACEHOLDER)
-                .setArrival(DEFAULT_TEST_ARRIVAL_PLACEHOLDER)
-                .setLanguage(DEFAULT_TEST_LANGUAGE)
-                .setLayers(DEFAULT_TEST_PELIAS_LAYERS)
-                .build();
+        ApiToken apiToken = new ApiToken();
+        apiToken.setProtocol(PROTOCOL);
+        apiToken.setHost(HOST);
+        apiToken.setPort(PELIAS_PORT);
+        apiToken.setApiVersion(DEFAULT_TEST_PELIAS_API_VERSION);
+        apiToken.setMaxResults(DEFAULT_TEST_PELIAS_REVERSE_RESULTS);
+        apiToken.setDeparture(DEFAULT_TEST_DEPARTURE_PLACEHOLDER);
+        apiToken.setArrival(DEFAULT_TEST_ARRIVAL_PLACEHOLDER);
+        apiToken.setLanguage(DEFAULT_TEST_LANGUAGE);
+        apiToken.setLayers(DEFAULT_TEST_PELIAS_LAYERS);
+        return apiToken;
     }
 
     // Now here is coming {@link getOpenTripPlannerConfiguredApiToken} {@link getOtpConfiguredFastLaneApiToken}
     // and {@link getOtpConfiguredSlowLaneApiToken} which are used for journey call as well as nearest stations
 
     public static ApiToken getJourneyOtpFastLaneApiToken() {
-        return new ApiToken.ApiTokenBuilder(getOtpConfiguredFastLaneApiToken())
-                .setLanguage(DEFAULT_TEST_LANGUAGE)
-                .setIsArrivalDateTime(DEFAULT_TEST_IS_ARRIVAL_DATE_TIME)
-                .setDateTime(DEFAULT_TEST_DATE_TIME)
-                .setDeparture(DEFAULT_TEST_DEPARTURE)
-                .setDepartureCoordinate(DEFAULT_TEST_DEPARTURE_COORDINATE)
-                .setArrival(DEFAULT_TEST_ARRIVAL)
-                .setArrivalCoordinate(DEFAULT_TEST_ARRIVAL_COORDINATE)
-                .build();
+        ApiToken apiToken = new ApiToken(getOtpConfiguredFastLaneApiToken());
+        apiToken.setLanguage(DEFAULT_TEST_LANGUAGE);
+        apiToken.setIsArrivalDateTime(DEFAULT_TEST_IS_ARRIVAL_DATE_TIME);
+        apiToken.setDateTime(DEFAULT_TEST_DATE_TIME);
+        apiToken.setDeparture(DEFAULT_TEST_DEPARTURE);
+        apiToken.setDepartureCoordinate(DEFAULT_TEST_DEPARTURE_COORDINATE);
+        apiToken.setArrival(DEFAULT_TEST_ARRIVAL);
+        apiToken.setArrivalCoordinate(DEFAULT_TEST_ARRIVAL_COORDINATE);
+        return apiToken;
     }
 
     public static ApiToken getJourneyOtpSlowLaneApiToken() {
-        return new ApiToken.ApiTokenBuilder(getOtpConfiguredSlowLaneApiToken())
-                .setLanguage(DEFAULT_TEST_LANGUAGE)
-                .setIsArrivalDateTime(DEFAULT_TEST_IS_ARRIVAL_DATE_TIME)
-                .setDateTime(DEFAULT_TEST_DATE_TIME)
-                .setDeparture(DEFAULT_TEST_DEPARTURE)
-                .setDepartureCoordinate(DEFAULT_TEST_DEPARTURE_COORDINATE)
-                .setArrival(DEFAULT_TEST_ARRIVAL)
-                .setArrivalCoordinate(DEFAULT_TEST_ARRIVAL_COORDINATE)
-                .build();
+        ApiToken apiToken = new ApiToken(getOtpConfiguredSlowLaneApiToken());
+        apiToken.setLanguage(DEFAULT_TEST_LANGUAGE);
+        apiToken.setIsArrivalDateTime(DEFAULT_TEST_IS_ARRIVAL_DATE_TIME);
+        apiToken.setDateTime(DEFAULT_TEST_DATE_TIME);
+        apiToken.setDeparture(DEFAULT_TEST_DEPARTURE);
+        apiToken.setDepartureCoordinate(DEFAULT_TEST_DEPARTURE_COORDINATE);
+        apiToken.setArrival(DEFAULT_TEST_ARRIVAL);
+        apiToken.setArrivalCoordinate(DEFAULT_TEST_ARRIVAL_COORDINATE);
+        return apiToken;
     }
     // End
 
     // Start
     // Nearest stations token request chain from stargateService to OpenTripPlanner
     public static ApiToken getNearestStationsUserRequestToken() {
-        return new ApiToken.ApiTokenBuilder()
-                .setArrivalCoordinate(DEFAULT_TEST_DEPARTURE_COORDINATE)
-                .setRadiusInKilometers(DEFAULT_TEST_RADIUS_IN_KILOMETERS)
-                .setLanguage(DEFAULT_TEST_LANGUAGE)
-                .build();
+        ApiToken apiToken = new ApiToken();
+        apiToken.setArrivalCoordinate(DEFAULT_TEST_DEPARTURE_COORDINATE);
+        apiToken.setRadiusInKilometers(DEFAULT_TEST_RADIUS_IN_KILOMETERS);
+        apiToken.setLanguage(DEFAULT_TEST_LANGUAGE);
+        return apiToken;
     }
 
     public static ApiToken getConfiguredNearestStationsOtpMapperApiToken() {
-        return new ApiToken.ApiTokenBuilder()
-                .setProtocol(PROTOCOL)
-                .setHost(HOST)
-                .setPort(OTP_MAPPER_SERVICE_PORT)
-                .setPath(NEAREST_STATIONS_CONTROLLER_PATH)
-                .build();
+        ApiToken apiToken = new ApiToken();
+        apiToken.setProtocol(PROTOCOL);
+        apiToken.setHost(HOST);
+        apiToken.setPort(OTP_MAPPER_SERVICE_PORT);
+        apiToken.setPath(NEAREST_STATIONS_CONTROLLER_PATH);
+        return apiToken;
     }
 
     public static ApiToken getNearestStationsOtpMapperApiToken() {
-        return new ApiToken.ApiTokenBuilder()
-                .setProtocol(PROTOCOL)
-                .setHost(HOST)
-                .setPort(OTP_MAPPER_SERVICE_PORT)
-                .setPath(NEAREST_STATIONS_CONTROLLER_PATH)
-                .setArrivalCoordinate(DEFAULT_TEST_DEPARTURE_COORDINATE)
-                .setRadiusInKilometers(DEFAULT_TEST_RADIUS_IN_KILOMETERS)
-                .setLanguage(DEFAULT_TEST_LANGUAGE)
-                .build();
+        ApiToken apiToken = new ApiToken();
+        apiToken.setProtocol(PROTOCOL);
+        apiToken.setHost(HOST);
+        apiToken.setPort(OTP_MAPPER_SERVICE_PORT);
+        apiToken.setPath(NEAREST_STATIONS_CONTROLLER_PATH);
+        apiToken.setArrivalCoordinate(DEFAULT_TEST_DEPARTURE_COORDINATE);
+        apiToken.setRadiusInKilometers(DEFAULT_TEST_RADIUS_IN_KILOMETERS);
+        apiToken.setLanguage(DEFAULT_TEST_LANGUAGE);
+        return apiToken;
     }
 
     // Now here is coming {@link getOpenTripPlannerConfiguredApiToken} {@link getOtpConfiguredFastLaneApiToken}
     // and {@link getOtpConfiguredSlowLaneApiToken} which are used for journey call as well as nearest stations
 
     public static ApiToken getNearestStationsOtpFastLaneApiToken() {
-        return new ApiToken.ApiTokenBuilder(getOtpConfiguredFastLaneApiToken())
-                .setArrivalCoordinate(DEFAULT_TEST_DEPARTURE_COORDINATE)
-                .setRadiusInKilometers(DEFAULT_TEST_RADIUS_IN_KILOMETERS)
-                .setLanguage(DEFAULT_TEST_LANGUAGE)
-                .build();
+        ApiToken apiToken = new ApiToken(getOtpConfiguredFastLaneApiToken());
+        apiToken.setArrivalCoordinate(DEFAULT_TEST_DEPARTURE_COORDINATE);
+        apiToken.setRadiusInKilometers(DEFAULT_TEST_RADIUS_IN_KILOMETERS);
+        apiToken.setLanguage(DEFAULT_TEST_LANGUAGE);
+        return apiToken;
     }
 
     public static ApiToken getNearestStationsOtpSlowLaneApiToken() {
-        return new ApiToken.ApiTokenBuilder(getOtpConfiguredSlowLaneApiToken())
-                .setArrivalCoordinate(DEFAULT_TEST_DEPARTURE_COORDINATE)
-                .setRadiusInKilometers(DEFAULT_TEST_RADIUS_IN_KILOMETERS)
-                .setLanguage(DEFAULT_TEST_LANGUAGE)
-                .build();
+        ApiToken apiToken = new ApiToken(getOtpConfiguredSlowLaneApiToken());
+        apiToken.setArrivalCoordinate(DEFAULT_TEST_DEPARTURE_COORDINATE);
+        apiToken.setRadiusInKilometers(DEFAULT_TEST_RADIUS_IN_KILOMETERS);
+        apiToken.setLanguage(DEFAULT_TEST_LANGUAGE);
+        return apiToken;
     }
 
     // Start
     // Both journey call and nearest stations call
     public static ApiToken getOtpConfiguredFastLaneApiToken() {
-        return getOpenTripPlannerConfiguredApiToken()
-                .setPort(OTP_FAST_LANE_PORT)
-                .setRouter(OTP_FAST_LANE_ROUTER)
-                .build();
+        ApiToken apiToken = new ApiToken(getOpenTripPlannerConfiguredApiToken());
+        apiToken.setPort(OTP_FAST_LANE_PORT);
+        apiToken.setRouter(OTP_FAST_LANE_ROUTER);
+        return apiToken;
     }
 
     public static ApiToken getOtpConfiguredSlowLaneApiToken() {
-        return getOpenTripPlannerConfiguredApiToken()
-                .setPort(OTP_SLOW_LANE_PORT)
-                .setRouter(OTP_SLOW_LANE_ROUTER)
-                .build();
+        ApiToken apiToken = new ApiToken(getOpenTripPlannerConfiguredApiToken());
+        apiToken.setPort(OTP_SLOW_LANE_PORT);
+        apiToken.setRouter(OTP_SLOW_LANE_ROUTER);
+        return apiToken;
     }
 
-    private static ApiToken.ApiTokenBuilder getOpenTripPlannerConfiguredApiToken() {
-        return new ApiToken.ApiTokenBuilder()
-                .setProtocol(PROTOCOL)
-                .setHost(HOST)
-                .setMaxResults(DEFAULT_TEST_MAX_RESULTS);
+    private static ApiToken getOpenTripPlannerConfiguredApiToken() {
+        ApiToken apiToken = new ApiToken();
+        apiToken.setProtocol(PROTOCOL);
+        apiToken.setHost(HOST);
+        apiToken.setMaxResults(DEFAULT_TEST_MAX_RESULTS);
+        return apiToken;
     }
     // End
 
     // Start
     // Autocomplete Token Request Chain from StargateService to DravelOpsPelias
     public static ApiToken getAutocompleteUserRequestToken() {
-        return new ApiToken.ApiTokenBuilder()
-                .setDeparture(DEFAULT_TEST_DEPARTURE)
-                .setLanguage(DEFAULT_TEST_LANGUAGE)
-                .build();
+        ApiToken apiToken = new ApiToken();
+        apiToken.setDeparture(DEFAULT_TEST_DEPARTURE);
+        apiToken.setLanguage(DEFAULT_TEST_LANGUAGE);
+        return apiToken;
     }
 
     public static ApiToken getConfiguredAutocompleteBoxServiceApiToken() {
-        return new ApiToken.ApiTokenBuilder()
-                .setProtocol(PROTOCOL)
-                .setHost(HOST)
-                .setPort(BOX_SERVICE_PORT)
-                .setPath(AUTOCOMPLETE_ADDRESSES_CONTROLLER_PATH)
-                .build();
+        ApiToken apiToken = new ApiToken();
+        apiToken.setProtocol(PROTOCOL);
+        apiToken.setHost(HOST);
+        apiToken.setPort(BOX_SERVICE_PORT);
+        apiToken.setPath(AUTOCOMPLETE_ADDRESSES_CONTROLLER_PATH);
+        return apiToken;
     }
 
     public static ApiToken getAutocompleteBoxServiceApiToken() {
-        return new ApiToken.ApiTokenBuilder()
-                .setProtocol(PROTOCOL)
-                .setHost(HOST)
-                .setPort(BOX_SERVICE_PORT)
-                .setPath(AUTOCOMPLETE_ADDRESSES_CONTROLLER_PATH)
-                .setDeparture(DEFAULT_TEST_DEPARTURE)
-                .setLanguage(DEFAULT_TEST_LANGUAGE)
-                .build();
+        ApiToken apiToken = new ApiToken();
+        apiToken.setProtocol(PROTOCOL);
+        apiToken.setHost(HOST);
+        apiToken.setPort(BOX_SERVICE_PORT);
+        apiToken.setPath(AUTOCOMPLETE_ADDRESSES_CONTROLLER_PATH);
+        apiToken.setDeparture(DEFAULT_TEST_DEPARTURE);
+        apiToken.setLanguage(DEFAULT_TEST_LANGUAGE);
+        return apiToken;
     }
 
     // Now here is coming {@link getConfiguredPeliasApiToken} which is used for autocomplete call
     // as well as nearest addresses call
 
     public static ApiToken getPeliasAutocompleteApiToken() {
-        return new ApiToken.ApiTokenBuilder()
-                .setProtocol(PROTOCOL)
-                .setHost(HOST)
-                .setPort(PELIAS_PORT)
-                .setMaxResults(DEFAULT_TEST_MAX_RESULTS)
-                .setLayers(DEFAULT_TEST_PELIAS_LAYERS)
-                .setBox(getStationPersistenceBox())
-                .setApiVersion(DEFAULT_TEST_PELIAS_API_VERSION)
-                .setDeparture(DEFAULT_TEST_DEPARTURE)
-                .setLanguage(DEFAULT_TEST_LANGUAGE)
-                .build();
+        ApiToken apiToken = new ApiToken();
+        apiToken.setProtocol(PROTOCOL);
+        apiToken.setHost(HOST);
+        apiToken.setPort(PELIAS_PORT);
+        apiToken.setMaxResults(DEFAULT_TEST_MAX_RESULTS);
+        apiToken.setLayers(DEFAULT_TEST_PELIAS_LAYERS);
+        apiToken.setBox(getStationPersistenceBox());
+        apiToken.setApiVersion(DEFAULT_TEST_PELIAS_API_VERSION);
+        apiToken.setDeparture(DEFAULT_TEST_DEPARTURE);
+        apiToken.setLanguage(DEFAULT_TEST_LANGUAGE);
+        return apiToken;
     }
     // End
 
     // Start
     // Nearest Addresses Token Request Chain from StargateService to DravelOpsPelias
     public static ApiToken getNearestAddressesUserRequestToken() {
-        return new ApiToken.ApiTokenBuilder()
-                .setArrivalCoordinate(DEFAULT_TEST_ARRIVAL_COORDINATE)
-                .setRadiusInKilometers(DEFAULT_TEST_RADIUS_IN_KILOMETERS)
-                .setLanguage(DEFAULT_TEST_LANGUAGE)
-                .build();
+        ApiToken apiToken = new ApiToken();
+        apiToken.setArrivalCoordinate(DEFAULT_TEST_ARRIVAL_COORDINATE);
+        apiToken.setRadiusInKilometers(DEFAULT_TEST_RADIUS_IN_KILOMETERS);
+        apiToken.setLanguage(DEFAULT_TEST_LANGUAGE);
+        return apiToken;
     }
 
     public static ApiToken getConfiguredNearestAddressesBoxServiceApiToken() {
-        return new ApiToken.ApiTokenBuilder()
-                .setProtocol(PROTOCOL)
-                .setHost(HOST)
-                .setPort(BOX_SERVICE_PORT)
-                .setPath(NEAREST_ADDRESSES_CONTROLLER_PATH)
-                .build();
+        ApiToken apiToken = new ApiToken();
+        apiToken.setProtocol(PROTOCOL);
+        apiToken.setHost(HOST);
+        apiToken.setPort(BOX_SERVICE_PORT);
+        apiToken.setPath(NEAREST_ADDRESSES_CONTROLLER_PATH);
+        return apiToken;
     }
 
     public static ApiToken getNearestAddressesBoxServiceApiToken() {
-        return new ApiToken.ApiTokenBuilder()
-                .setProtocol(PROTOCOL)
-                .setHost(HOST)
-                .setPort(BOX_SERVICE_PORT)
-                .setPath(NEAREST_ADDRESSES_CONTROLLER_PATH)
-                .setArrivalCoordinate(DEFAULT_TEST_ARRIVAL_COORDINATE)
-                .setRadiusInKilometers(DEFAULT_TEST_RADIUS_IN_KILOMETERS)
-                .setLanguage(DEFAULT_TEST_LANGUAGE)
-                .build();
+        ApiToken apiToken = new ApiToken();
+        apiToken.setProtocol(PROTOCOL);
+        apiToken.setHost(HOST);
+        apiToken.setPort(BOX_SERVICE_PORT);
+        apiToken.setPath(NEAREST_ADDRESSES_CONTROLLER_PATH);
+        apiToken.setArrivalCoordinate(DEFAULT_TEST_ARRIVAL_COORDINATE);
+        apiToken.setRadiusInKilometers(DEFAULT_TEST_RADIUS_IN_KILOMETERS);
+        apiToken.setLanguage(DEFAULT_TEST_LANGUAGE);
+        return apiToken;
     }
 
     // Now here is coming {@link getConfiguredPeliasApiToken} which is used for autocomplete call
     // as well as nearest addresses call
 
     public static ApiToken getPeliasNearestAddressesApiToken() {
-        return new ApiToken.ApiTokenBuilder()
-                .setProtocol(PROTOCOL)
-                .setHost(HOST)
-                .setPort(PELIAS_PORT)
-                .setMaxResults(DEFAULT_TEST_MAX_RESULTS)
-                .setLayers(DEFAULT_TEST_PELIAS_LAYERS)
-                .setApiVersion(DEFAULT_TEST_PELIAS_API_VERSION)
-                .setArrivalCoordinate(DEFAULT_TEST_ARRIVAL_COORDINATE)
-                .setRadiusInKilometers(DEFAULT_TEST_RADIUS_IN_KILOMETERS)
-                .setLanguage(DEFAULT_TEST_LANGUAGE)
-                .build();
+        ApiToken apiToken = new ApiToken();
+        apiToken.setProtocol(PROTOCOL);
+        apiToken.setHost(HOST);
+        apiToken.setPort(PELIAS_PORT);
+        apiToken.setMaxResults(DEFAULT_TEST_MAX_RESULTS);
+        apiToken.setLayers(DEFAULT_TEST_PELIAS_LAYERS);
+        apiToken.setApiVersion(DEFAULT_TEST_PELIAS_API_VERSION);
+        apiToken.setArrivalCoordinate(DEFAULT_TEST_ARRIVAL_COORDINATE);
+        apiToken.setRadiusInKilometers(DEFAULT_TEST_RADIUS_IN_KILOMETERS);
+        apiToken.setLanguage(DEFAULT_TEST_LANGUAGE);
+        return apiToken;
     }
     // End
 
     // Start
     // Both autocomplete call and nearest addresses call
     public static ApiToken getConfiguredPeliasApiToken() {
-        return new ApiToken.ApiTokenBuilder()
-                .setProtocol(PROTOCOL)
-                .setHost(HOST)
-                .setPort(PELIAS_PORT)
-                .setApiVersion(DEFAULT_TEST_PELIAS_API_VERSION)
-                .setMaxResults(DEFAULT_TEST_MAX_RESULTS)
-                .setLayers(DEFAULT_TEST_PELIAS_LAYERS)
-                .build();
+        ApiToken apiToken = new ApiToken();
+        apiToken.setProtocol(PROTOCOL);
+        apiToken.setHost(HOST);
+        apiToken.setPort(PELIAS_PORT);
+        apiToken.setApiVersion(DEFAULT_TEST_PELIAS_API_VERSION);
+        apiToken.setMaxResults(DEFAULT_TEST_MAX_RESULTS);
+        apiToken.setLayers(DEFAULT_TEST_PELIAS_LAYERS);
+        return apiToken;
     }
     // End
 
     // HazelcastApiToken
     public static ApiToken getHazelcastApiToken() {
-        return new ApiToken.ApiTokenBuilder()
-                .setMaxPastDaysInCalendar(DEFAULT_TEST_MAX_PAST_DAYS_IN_CALENDAR)
-                .setJourneySearchWindowInMinutes(DEFAULT_TEST_JOURNEY_SEARCH_WINDOW)
-                .build();
+        ApiToken apiToken = new ApiToken();
+        apiToken.setMaxPastDaysInCalendar(DEFAULT_TEST_MAX_PAST_DAYS_IN_CALENDAR);
+        apiToken.setJourneySearchWindowInMinutes(DEFAULT_TEST_JOURNEY_SEARCH_WINDOW);
+        return apiToken;
     }
 
     // GtfsFileApiToken
     public static ApiToken getSbgGtfsApiToken() {
-        return new ApiToken.ApiTokenBuilder()
-                .setGtfsProvider(DEFAULT_TEST_GTFS_PROVIDER)
-                .setGtfsUrl(DEFAULT_TEST_GTFS_URL)
-                .setHeaders(DEFAULT_TEST_HEADERS)
-                .build();
+        ApiToken apiToken = new ApiToken();
+        apiToken.setGtfsProvider(DEFAULT_TEST_GTFS_PROVIDER);
+        apiToken.setGtfsUrl(DEFAULT_TEST_GTFS_URL);
+        apiToken.setHeaders(DEFAULT_TEST_HEADERS);
+        return apiToken;
     }
 
     public static ApiToken getRnvGtfsApiToken() {
-        return new ApiToken.ApiTokenBuilder()
-                .setGtfsProvider("rnv")
-                .setGtfsUrl("https://gtfs-sandbox-dds.rnv-online.de/latest/gtfs.zip")
-                .build();
+        ApiToken apiToken = new ApiToken();
+        apiToken.setGtfsProvider("rnv");
+        apiToken.setGtfsUrl("https://gtfs-sandbox-dds.rnv-online.de/latest/gtfs.zip");
+        return apiToken;
     }
 
     public static ApiToken getConfiguredTravelPointPersistenceApiToken() {
-        return getConfiguredStationPersistenceApiToken()
-                .setPath("/travelpoints/get")
-                .build();
+        ApiToken apiToken = new ApiToken(getConfiguredStationPersistenceApiToken());
+        apiToken.setPath("/travelpoints/get");
+        return apiToken;
     }
 
     public static ApiToken getConfiguredPolygonPersistenceApiToken() {
-        return getConfiguredStationPersistenceApiToken()
-                .setPath("/geocoding/get/operatingPolygon")
-                .build();
+        ApiToken apiToken = new ApiToken(getConfiguredStationPersistenceApiToken());
+        apiToken.setPath("/geocoding/get/operatingPolygon");
+        return apiToken;
     }
 
     public static ApiToken getConfiguredBoxPersistenceApiToken() {
-        return getConfiguredStationPersistenceApiToken()
-                .setPath("/geocoding/get/operatingBox")
-                .setRetryTimeInSeconds(DEFAULT_TEST_RETRY_TIME_IN_SECONDS)
-                .build();
+        ApiToken apiToken = new ApiToken(getConfiguredStationPersistenceApiToken());
+        apiToken.setPath("/geocoding/get/operatingBox");
+        apiToken.setRetryTimeInSeconds(DEFAULT_TEST_RETRY_TIME_IN_SECONDS);
+        return apiToken;
     }
 
-    private static ApiToken.ApiTokenBuilder getConfiguredStationPersistenceApiToken() {
-        return new ApiToken.ApiTokenBuilder()
-                .setProtocol(PROTOCOL)
-                .setHost(HOST)
-                .setPort(STATION_PERSISTENCE_PORT);
+    private static ApiToken getConfiguredStationPersistenceApiToken() {
+        ApiToken apiToken = new ApiToken();
+        apiToken.setProtocol(PROTOCOL);
+        apiToken.setHost(HOST);
+        apiToken.setPort(STATION_PERSISTENCE_PORT);
+        return apiToken;
     }
 
-    private static List<String> getDefaultTestPeliasLayers() {
+    private static List<String>getDefaultTestPeliasLayers() {
         return List.of(
                 "venue",
                 "address",

--- a/src/test/java/de/blackforestsolutions/dravelopsdatamodel/objectmothers/ApiTokenObjectMother.java
+++ b/src/test/java/de/blackforestsolutions/dravelopsdatamodel/objectmothers/ApiTokenObjectMother.java
@@ -64,7 +64,7 @@ public class ApiTokenObjectMother {
     private static final List<String> DEFAULT_TEST_PELIAS_LAYERS = ApiTokenObjectMother.getDefaultTestPeliasLayers();
     private static final String DEFAULT_TEST_GTFS_PROVIDER = "sbg";
     private static final String DEFAULT_TEST_GTFS_URL = "http://nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/sbg.zip";
-    private static final long DEFAULT_TEST_RETRY_TIME_IN_SECONDS = 10L;
+    private static final long DEFAULT_TEST_RETRY_TIME_IN_MILLISECONDS = 10L;
 
 
     public static ApiToken getApiTokenWithNoEmptyFields() {
@@ -93,7 +93,7 @@ public class ApiTokenObjectMother {
         apiToken.setGtfsProvider(DEFAULT_TEST_GTFS_PROVIDER);
         apiToken.setGtfsUrl(DEFAULT_TEST_GTFS_URL);
         apiToken.setHeaders(DEFAULT_TEST_HEADERS);
-        apiToken.setRetryTimeInSeconds(DEFAULT_TEST_RETRY_TIME_IN_SECONDS);
+        apiToken.setRetryTimeInMilliseconds(DEFAULT_TEST_RETRY_TIME_IN_MILLISECONDS);
         return apiToken;
     }
 
@@ -447,7 +447,7 @@ public class ApiTokenObjectMother {
     public static ApiToken getConfiguredBoxPersistenceApiToken() {
         ApiToken apiToken = new ApiToken(getConfiguredStationPersistenceApiToken());
         apiToken.setPath("/geocoding/get/operatingBox");
-        apiToken.setRetryTimeInSeconds(DEFAULT_TEST_RETRY_TIME_IN_SECONDS);
+        apiToken.setRetryTimeInMilliseconds(DEFAULT_TEST_RETRY_TIME_IN_MILLISECONDS);
         return apiToken;
     }
 

--- a/src/test/java/de/blackforestsolutions/dravelopsdatamodel/util/DravelOpsHttpCallBuilderTest.java
+++ b/src/test/java/de/blackforestsolutions/dravelopsdatamodel/util/DravelOpsHttpCallBuilderTest.java
@@ -27,10 +27,10 @@ class DravelOpsHttpCallBuilderTest {
 
     @Test
     void test_buildUrlWith_protocol_host_port_as_zero_and_path_returns_correct_url() {
-        ApiToken.ApiTokenBuilder testData = new ApiToken.ApiTokenBuilder(getApiTokenWithNoEmptyFields());
+        ApiToken testData = new ApiToken(getApiTokenWithNoEmptyFields());
         testData.setPort(0);
 
-        URL result = DravelOpsHttpCallBuilder.buildUrlWith(testData.build());
+        URL result = DravelOpsHttpCallBuilder.buildUrlWith(testData);
 
         assertThat(result.getProtocol()).isEqualTo(testData.getProtocol());
         assertThat(result.getHost()).isEqualTo(testData.getHost());
@@ -41,10 +41,10 @@ class DravelOpsHttpCallBuilderTest {
 
     @Test
     void test_buildUrlWith_protocol_host_port_as_minus_one_and_path_returns_correct_url() {
-        ApiToken.ApiTokenBuilder testData = new ApiToken.ApiTokenBuilder(getApiTokenWithNoEmptyFields());
+        ApiToken testData = new ApiToken(getApiTokenWithNoEmptyFields());
         testData.setPort(-1);
 
-        URL result = DravelOpsHttpCallBuilder.buildUrlWith(testData.build());
+        URL result = DravelOpsHttpCallBuilder.buildUrlWith(testData);
 
         assertThat(result.getProtocol()).isEqualTo(testData.getProtocol());
         assertThat(result.getHost()).isEqualTo(testData.getHost());
@@ -55,49 +55,49 @@ class DravelOpsHttpCallBuilderTest {
 
     @Test
     void test_buildUrlWith_protocol_as_null_host_port_and_path_throws_exception() {
-        ApiToken.ApiTokenBuilder testData = new ApiToken.ApiTokenBuilder(getApiTokenWithNoEmptyFields());
+        ApiToken testData = new ApiToken(getApiTokenWithNoEmptyFields());
         testData.setProtocol(null);
 
-        assertThrows(NullPointerException.class, () -> DravelOpsHttpCallBuilder.buildUrlWith(testData.build()));
+        assertThrows(NullPointerException.class, () -> DravelOpsHttpCallBuilder.buildUrlWith(testData));
     }
 
     @Test
     void test_buildUrlWith_wrong_protocol_host_port_path_throws_exception() {
-        ApiToken.ApiTokenBuilder builder = new ApiToken.ApiTokenBuilder(getApiTokenWithNoEmptyFields());
+        ApiToken builder = new ApiToken(getApiTokenWithNoEmptyFields());
         builder.setProtocol("wrong");
 
-        assertThrows(UncheckedIOException.class, () -> DravelOpsHttpCallBuilder.buildUrlWith(builder.build()));
+        assertThrows(UncheckedIOException.class, () -> DravelOpsHttpCallBuilder.buildUrlWith(builder));
     }
 
     @Test
     void test_buildUrlWith_wrong_testData_throws_exception() {
-        ApiToken.ApiTokenBuilder testData = new ApiToken.ApiTokenBuilder(getApiTokenWithNoEmptyFields());
+        ApiToken testData = new ApiToken(getApiTokenWithNoEmptyFields());
         testData.setHost(null);
 
-        assertThrows(NullPointerException.class, () -> DravelOpsHttpCallBuilder.buildUrlWith(testData.build()));
+        assertThrows(NullPointerException.class, () -> DravelOpsHttpCallBuilder.buildUrlWith(testData));
     }
 
     @Test
     void test_buildUrlWith_protocol_host_as_null_port_and_path_throws_exception() {
-        ApiToken.ApiTokenBuilder testData = new ApiToken.ApiTokenBuilder(getApiTokenWithNoEmptyFields());
+        ApiToken testData = new ApiToken(getApiTokenWithNoEmptyFields());
         testData.setHost(null);
 
-        assertThrows(NullPointerException.class, () -> DravelOpsHttpCallBuilder.buildUrlWith(testData.build()));
+        assertThrows(NullPointerException.class, () -> DravelOpsHttpCallBuilder.buildUrlWith(testData));
     }
 
     @Test
     void test_buildUrlWith_protocol_host_port_as_null_and_path_throws_exception() {
-        ApiToken.ApiTokenBuilder testData = new ApiToken.ApiTokenBuilder(getApiTokenWithNoEmptyFields());
+        ApiToken testData = new ApiToken(getApiTokenWithNoEmptyFields());
         testData.setPort(null);
 
-        assertThrows(NullPointerException.class, () -> DravelOpsHttpCallBuilder.buildUrlWith(testData.build()));
+        assertThrows(NullPointerException.class, () -> DravelOpsHttpCallBuilder.buildUrlWith(testData));
     }
 
     @Test
     void test_buildUrlWith_protocol_host_port_and_path_as_null_throws_exception() {
-        ApiToken.ApiTokenBuilder testData = new ApiToken.ApiTokenBuilder(getApiTokenWithNoEmptyFields());
+        ApiToken testData = new ApiToken(getApiTokenWithNoEmptyFields());
         testData.setPath(null);
 
-        assertThrows(NullPointerException.class, () -> DravelOpsHttpCallBuilder.buildUrlWith(testData.build()));
+        assertThrows(NullPointerException.class, () -> DravelOpsHttpCallBuilder.buildUrlWith(testData));
     }
 }


### PR DESCRIPTION
Das Builder Pattern musste leider entfernt werden, da es nicht kompatibel zu Springs @RefreshScope-Annotation ist.